### PR TITLE
Remove output "Heat_losses" due to duplication in heatport

### DIFF
--- a/Annex60/Experimental/Pipe/DoublePipeParallel.mo
+++ b/Annex60/Experimental/Pipe/DoublePipeParallel.mo
@@ -7,8 +7,6 @@ model DoublePipeParallel
       final allowFlowReversal1 = allowFlowReversal,
       final allowFlowReversal2 = allowFlowReversal);
 
-  output Modelica.SIunits.HeatFlowRate heat_losses "Heat losses in this pipe";
-
   // Geometric parameters
   final parameter Modelica.SIunits.Diameter diameter=pipeData.Di
     "Pipe diameter";
@@ -162,9 +160,6 @@ public
     annotation (Placement(transformation(extent={{-10,90},{10,110}})));
 
 equation
-  heat_losses = actualStream(port_b1.h_outflow) - actualStream(port_a1.h_outflow)
-     + actualStream(port_a2.h_outflow) - actualStream(port_b2.h_outflow);
-
   connect(senMasFlo.port_b, pipeSupplyAdiabaticPlugFlow.port_a)
     annotation (Line(points={{-16,60},{-13,60},{-10,60}}, color={0,127,255}));
   connect(senMasFlo.m_flow, pDETime_massFlow.m_flow) annotation (Line(points={{

--- a/Annex60/Experimental/Pipe/DoublePipe_PipeDelay.mo
+++ b/Annex60/Experimental/Pipe/DoublePipe_PipeDelay.mo
@@ -7,7 +7,6 @@ model DoublePipe_PipeDelay
       final allowFlowReversal1 = allowFlowReversal,
       final allowFlowReversal2 = allowFlowReversal);
 
-  output Modelica.SIunits.HeatFlowRate heat_losses "Heat losses in this pipe";
 
   // Geometric parameters
   final parameter Modelica.SIunits.Diameter diameter=pipeData.Di
@@ -171,8 +170,6 @@ public
     annotation (Placement(transformation(extent={{-10,90},{10,110}})));
 
 equation
-  heat_losses = actualStream(port_b1.h_outflow) - actualStream(port_a1.h_outflow)
-     + actualStream(port_a2.h_outflow) - actualStream(port_b2.h_outflow);
 
   connect(pipeSupplyAdiabaticPlugFlow.port_b, heatLossSupply.port_a)
     annotation (Line(points={{10,60},{52,60}},         color={0,127,255}));

--- a/Annex60/Experimental/Pipe/PipeHeatLossMod.mo
+++ b/Annex60/Experimental/Pipe/PipeHeatLossMod.mo
@@ -3,8 +3,6 @@ model PipeHeatLossMod
   "Pipe model using spatialDistribution for temperature delay with modified delay tracker"
   extends Annex60.Fluid.Interfaces.PartialTwoPort;
 
-  output Modelica.SIunits.HeatFlowRate heat_losses "Heat losses in this pipe";
-
   parameter Modelica.SIunits.Diameter diameter "Pipe diameter";
   parameter Modelica.SIunits.Length length "Pipe length";
   parameter Modelica.SIunits.Length thicknessIns "Thickness of pipe insulation";
@@ -123,7 +121,6 @@ public
   parameter Modelica.SIunits.MassFlowRate m_flowInit=0
     annotation (Dialog(tab="Initialization", enable=initDelay));
 equation
-  heat_losses = actualStream(port_b.h_outflow) - actualStream(port_a.h_outflow);
 
   connect(port_a, reverseHeatLoss.port_b)
     annotation (Line(points={{-100,0},{-80,0}}, color={0,127,255}));


### PR DESCRIPTION
Remove ``output`` from pipe models to avoid duplication of output of heatport. For #67 